### PR TITLE
pdksync - (MODULES-6805) metadata.json shows support for puppet 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.1.0 < 6.0.0"
+      "version_requirement": ">= 5.1.0 < 7.0.0"
     }
   ],
   "pdk-version": "1.7.0",


### PR DESCRIPTION
(MODULES-6805) metadata.json shows support for puppet 6
pdk version: `1.7.0` 
