### PR TITLE
pdksync - FM-8499 remove ubuntu 14 support

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -4,7 +4,7 @@ default:
   images: ['waffleimage/centos7']
 travis_deb:
   provisioner: docker
-  images: ['debian:8', 'debian:9', 'ubuntu:14.04', 'ubuntu:16.04', 'ubuntu:18.04']
+  images: ['debian:8', 'debian:9', 'ubuntu:16.04', 'ubuntu:18.04']
 travis_el:
   provisioner: docker
   images: ['centos:6', 'centos:7', 'oraclelinux:6', 'oraclelinux:7']
@@ -13,4 +13,4 @@ vagrant:
   images: ['centos/7', 'generic/ubuntu1804', 'gusztavvargadr/windows-server']
 release_checks:
   provisioner: vmpooler
-  images: ['centos-6-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'redhat-5-x86_64', 'redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'win-2008r2-x86_64', 'win-2012r2-x86_64', 'win-2016-x86_64', 'win-2019-x86_64', 'win-10-pro-x86_64']
+  images: ['centos-6-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'redhat-5-x86_64', 'redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'win-2008r2-x86_64', 'win-2012r2-x86_64', 'win-2016-x86_64', 'win-2019-x86_64', 'win-10-pro-x86_64']


### PR DESCRIPTION
FM-8499 remove ubuntu 14 support
pdk version: `1.14.0` 
